### PR TITLE
chore: replace `near-sdk-as` with other specific packages

### DIFF
--- a/assembly/__tests__/bencoded.spec.ts
+++ b/assembly/__tests__/bencoded.spec.ts
@@ -1,7 +1,7 @@
 import {BorshEncoder, BorshDecoder} from '../borsh'
 import { MS, Pair, Test } from '.';
 import {Encoder, Decoder} from ".."
-import { u128 } from 'near-sdk-as';
+import { u128 } from 'as-bignum';
 
 @serializable
 export class FooBar {

--- a/assembly/__tests__/index.ts
+++ b/assembly/__tests__/index.ts
@@ -1,4 +1,5 @@
-import { base64, u128 } from "near-sdk-as";
+import { u128 } from "as-bignum";
+import * as base64 from "as-base64";
 import { Encoder, Decoder } from "..";
 
 @serializable
@@ -9,20 +10,22 @@ export class Pair {
 
 @serializable
 export class Test {
-  public number:i32;
-  public str:string = "";
-  public arr:Array<Pair> = [];
+  public number: i32;
+  public str: string = "";
+  public arr: Array<Pair> = [];
 }
 
 @serializable
-export class LargerTest{
-  public number:i32=2;
-  public str:string="testing";
-  public arr:Array<i32>=[0,1];
-  public arpa:Array<Pair>=[{s1:0, s2:1}, {s1:2, s2:3}];
+export class LargerTest {
+  public number: i32 = 2;
+  public str: string = "testing";
+  public arr: Array<i32> = [0, 1];
+  public arpa: Array<Pair> = [
+    { s1: 0, s2: 1 },
+    { s1: 2, s2: 3 },
+  ];
   public f32_zero: f32;
 }
-
 
 @serializable
 export class FooBar {
@@ -41,7 +44,7 @@ export class FooBar {
   uint8arrays: Array<Uint8Array> = [];
   // TODO: Fix u64 array
   u64Arr: u64[] = [];
-}  
+}
 
 @serializable
 export class Nested {
@@ -64,12 +67,12 @@ export class Extends extends FooBar {
 }
 
 @serializable
-export class MS{
-  public map:Map<string, u32> = new Map<string, u32>();
-  public set:Set<u32> = new Set<u32>();
+export class MS {
+  public map: Map<string, u32> = new Map<string, u32>();
+  public set: Set<u32> = new Set<u32>();
 }
 
-export function initFooBar(f: FooBar): FooBar { 
+export function initFooBar(f: FooBar): FooBar {
   f.u32Arr = [42, 11];
   f.foo = 321;
   f.bar = 123;
@@ -89,7 +92,7 @@ export function initFooBar(f: FooBar): FooBar {
 export class WeirdMap {
   inner: Map<i32, string | null> = new Map();
 
-  add(i: i32):void{ 
+  add(i: i32): void {
     this.inner.set(i, null);
   }
 }

--- a/assembly/borsh/decoder.ts
+++ b/assembly/borsh/decoder.ts
@@ -1,5 +1,5 @@
 import {Decoder} from "..";
-import { u128 } from "near-sdk-as";
+import { u128 } from "as-bignum";
 import { DecodeBuffer } from "../buffer";
 
 export class BorshDecoder extends Decoder<ArrayBuffer>{

--- a/assembly/borsh/encoder.ts
+++ b/assembly/borsh/encoder.ts
@@ -1,5 +1,5 @@
 import {Encoder, EncodeBuffer} from "..";
-import { u128 } from "near-sdk-as";
+import { u128 } from "as-bignum";
 
 
 export class BorshEncoder extends Encoder<ArrayBuffer>{

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -1,4 +1,4 @@
-import { u128 } from "near-sdk-as";
+import { u128 } from "as-bignum";
 
 function isNull<T>(t: T): bool {
   if (isNullable<T>() || isReference<T>()) {

--- a/assembly/json/encoder.ts
+++ b/assembly/json/encoder.ts
@@ -1,5 +1,6 @@
 import {Encoder} from "..";
-import { base64, u128 } from "near-sdk-as";
+import { u128 } from "as-bignum";
+import * as base64 from "as-base64";
 
 export class JSONEncoder extends Encoder<string>{
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "near-sdk-as": "^3.2.0",
     "ts-mixer": "^5.4.1",
-    "visitor-as": "^0.6.0"
+    "visitor-as": "^0.6.0",
+    "as-bignum": "^0.2.17",
+    "as-base64": "^0.1.1"
   }
 }


### PR DESCRIPTION
Ref #3 
Replace `near-sdk-as` dependency with [`as-base64`](https://www.npmjs.com/package/as-base64) and [`as-bignum`](https://github.com/MaxGraey/as-bignum/)